### PR TITLE
Use the `short_description` field in metadata.

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "gatsby-theme-osiolabs-drupal",
   "description": "Base theme for integrating with members.osiolabs.com.",
-  "version": "1.0.1",
+  "version": "1.0.2",
   "author": "Joe Shindelar <joe@osiolabs.com>",
   "main": "index.js",
   "dependencies": {

--- a/src/components/Seo/Seo.jsx
+++ b/src/components/Seo/Seo.jsx
@@ -3,7 +3,7 @@ import PropTypes from 'prop-types';
 import Helmet from 'react-helmet';
 import { StaticQuery, graphql } from 'gatsby';
 
-function SEO({ description, lang, meta, keywords, title }) {
+function SEO({ description, lang, meta, keywords, title, image }) {
   return (
     <StaticQuery
       query={detailsQuery}
@@ -59,6 +59,20 @@ function SEO({ description, lang, meta, keywords, title }) {
                     }
                   : []
               )
+              .concat(
+                image !== null
+                  ? [
+                      {
+                        name: `twitter:image`,
+                        content: `${site.siteMetadata.siteUrl}${image}`,
+                      },
+                      {
+                        name: `og:image`,
+                        content: `${site.siteMetadata.siteUrl}${image}`,
+                      },
+                    ]
+                  : []
+              )
               .concat(meta)}
           />
         );
@@ -71,6 +85,7 @@ SEO.defaultProps = {
   lang: 'en',
   meta: [],
   keywords: [],
+  image: null,
 };
 
 SEO.propTypes = {
@@ -79,6 +94,7 @@ SEO.propTypes = {
   meta: PropTypes.array,
   keywords: PropTypes.arrayOf(PropTypes.string),
   title: PropTypes.string.isRequired,
+  image: PropTypes.string,
 };
 
 export default SEO;

--- a/src/components/Tutorial/TutorialTemplate.jsx
+++ b/src/components/Tutorial/TutorialTemplate.jsx
@@ -46,7 +46,7 @@ const TutorialTemplate = props => {
     <div className="tutorial">
       <SEO
         title={tutorial.title}
-        description={tutorial.summary.value}
+        description={tutorial.short_description}
         meta={[{ name: 'og:type', content: 'article' }]}
       />
       <Grid columns={2} stackable>

--- a/src/components/Tutorial/TutorialTemplate.jsx
+++ b/src/components/Tutorial/TutorialTemplate.jsx
@@ -47,6 +47,11 @@ const TutorialTemplate = props => {
       <SEO
         title={tutorial.title}
         description={tutorial.short_description}
+        image={
+          tutorial.relationships.promotional_image &&
+          tutorial.relationships.promotional_image.relationships.imageFile
+            .localFile.childImageSharp.original.src
+        }
         meta={[{ name: 'og:type', content: 'article' }]}
       />
       <Grid columns={2} stackable>

--- a/src/templates/tutorial.js
+++ b/src/templates/tutorial.js
@@ -43,6 +43,19 @@ export const query = graphql`
             }
           }
         }
+        promotional_image {
+          relationships {
+            imageFile {
+              localFile {
+                childImageSharp {
+                  original {
+                    src
+                  }
+                }
+              }
+            }
+          }
+        }
       }
     }
   }

--- a/src/templates/tutorial.js
+++ b/src/templates/tutorial.js
@@ -21,6 +21,7 @@ export const query = graphql`
       body {
         processed
       }
+      short_description
       tutorial_access
       path {
         alias


### PR DESCRIPTION
This PR adds the `short_description` field to our GraphQL queries for tutorials, and then makes use of it for the relevant metatags in the template.