### PR TITLE
Fixing the way redirects are created, so that they are always followed.

### DIFF
--- a/gatsby-node.js
+++ b/gatsby-node.js
@@ -86,6 +86,7 @@ exports.createPages = async ({ actions, graphql }) => {
             toPath: path,
             isPermanent: true,
             redirectInBrowser: true,
+            force: true,
           });
         }
 
@@ -140,6 +141,7 @@ exports.createPages = async ({ actions, graphql }) => {
             toPath: path,
             isPermanent: true,
             redirectInBrowser: true,
+            force: true,
           });
         }
 

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "gatsby-theme-osiolabs-drupal",
   "description": "Base theme for integrating with members.osiolabs.com.",
-  "version": "1.0.3",
+  "version": "1.0.4",
   "author": "Joe Shindelar <joe@osiolabs.com>",
   "main": "index.js",
   "dependencies": {


### PR DESCRIPTION
Netlify's redirect API [is changing soon](https://community.netlify.com/t/changed-behavior-in-redirects/10084/4).

This PR makes sure the redirects we're creating from Drupal are forced, so that we're not dealing with content shadowing.