### PR TITLE
Initialize context providers in gatsby-ssr.js

### DIFF
--- a/gatsby-ssr.js
+++ b/gatsby-ssr.js
@@ -5,3 +5,29 @@
  */
 
 // You can delete this file if you're not using it
+import React from 'react';
+import TutorialListProvider from './src/hooks/useTutorialList/TutorialListProvider';
+import DrupalOauth from './src/components/drupal-oauth/DrupalOauth';
+import withDrupalOauthProvider from './src/components/drupal-oauth/withDrupalOauthProvider';
+import withDrupalOauthConsumer from './src/components/drupal-oauth/withDrupalOauthConsumer';
+
+// Initialize a new DrupalOauth client which we can use to seed the context
+// provider.
+const drupalOauthClient = DrupalOauth.createFromEnvironment();
+
+const OauthProvider = withDrupalOauthProvider(
+  drupalOauthClient,
+  React.Fragment
+);
+const TutorialListProviderWithOauthConsumer = withDrupalOauthConsumer(
+  TutorialListProvider
+);
+
+// eslint-disable-next-line react/prop-types
+export const wrapRootElement = ({ element }) => (
+  <OauthProvider>
+    <TutorialListProviderWithOauthConsumer>
+      {element}
+    </TutorialListProviderWithOauthConsumer>
+  </OauthProvider>
+);

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "gatsby-theme-osiolabs-drupal",
   "description": "Base theme for integrating with members.osiolabs.com.",
-  "version": "1.1.0",
+  "version": "1.1.1",
   "author": "Joe Shindelar <joe@osiolabs.com>",
   "main": "index.js",
   "dependencies": {


### PR DESCRIPTION
In https://github.com/OsioLabs/gatsby-theme-osiolabs-drupal/commit/03942304c541f65330643722d5bd0d43fbf2fa46 we refactored the Oauth Context provider code to use gatsby-browser, and to make it so that sites implementing this theme don't have to initialize the context themselves.

This works when using `gatsby develop`, but not when using `gatsby build`. To fix it, we also need to initialize the context providers in gatsby-ssr.js.

This fixes a problem where right now you can't run `npm run build` on heynode.com using the latest version of this theme without getting an error like this:

```txt
failed Building static HTML for pages - 10.962s

 ERROR #95313

Building static HTML failed for path "/tutorial/explore-timers-phase-nodes-event-loop"

See our docs page for more info on this error: https://gatsby.dev/debug-html


  23 | export const withDrupalOauthConsumer = Component => props => (
  24 |   <DrupalOauthContext.Consumer>
> 25 |     {({
     |       ^
  26 |       drupalOauthClient,
  27 |       userAuthenticated,
  28 |       currentUserId,


  WebpackError: TypeError: Cannot destructure property `drupalOauthClient` of 'undefined' or 'null'.

  - withDrupalOauthConsumer.jsx:25 Object.children
    node_modules/gatsby-theme-osiolabs-drupal/src/co
```

This is an exact copy of the code that's currently in gatsby-browser.js. The reason it works in `gatsby develop` right now is because that doesn't generate the static HTML files and only uses gatsby-browser and not gatsby-ssr.

