### PR TITLE
Remove babel-core in favor of @babel/core.

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "gatsby-theme-osiolabs-drupal",
   "description": "Base theme for integrating with members.osiolabs.com.",
-  "version": "1.1.1",
+  "version": "1.1.2",
   "author": "Joe Shindelar <joe@osiolabs.com>",
   "main": "index.js",
   "dependencies": {
@@ -45,7 +45,6 @@
     "@testing-library/jest-dom": "^4.0.0",
     "@testing-library/react": "^9.3.2",
     "@testing-library/react-hooks": "^3.2.1",
-    "babel-core": "^7.0.0-0",
     "babel-eslint": "^10.0.1",
     "babel-jest": "^23.6.0",
     "babel-preset-gatsby": "^0.1.3",


### PR DESCRIPTION
I'm now seeing this error when trying to build heynode.com on Netlify.

```txt
2:46:56 PM: failed Building production JavaScript and CSS bundles - 0.743s
2:46:56 PM: error Generating JavaScript bundles failed
2:46:56 PM: Cannot find module '@babel/core'
2:46:56 PM:  babel-loader@8 requires Babel 7.x (the package '@babel/core'). If you'd like to use Babel 6.x ('babel-core'), you should install 'babel-loader@7'.
2:46:56 PM: not finished run queries - 0.758s
```

It appears to be related to the fact we have both babel-core (Babel 7) and @babel/core (Babel 8). But, I'm also finding it difficult to replicate this problem on my local host so I'm not 100% sure if this is the right fix or not. I can confirm however that I can rm -rf node_modules/babel-core and everything at least still builds on my local.

@blakehall I'm hoping we can merge this in, and I can test it out via https://github.com/OsioLabs/heynode.com/pull/132. I can't really figure out any other way to test building this on Netlify.