### PR TITLE
Get tutorial progress working (somewhat)

### DIFF
--- a/src/hooks/useProgressIndicator.js
+++ b/src/hooks/useProgressIndicator.js
@@ -4,7 +4,7 @@ import { useTutorialList } from './useTutorialList';
 /**
  * React hook; Manage the progress for a specified tutorial.
  *
- * @param {boolean} initialValue
+ * @param {string} initialValue
  *   Initial progress value. TRUE for completed, FALSE for incomplete.
  * @param {string} entityId
  *   UUID of the Drupal entity that this progress is being tracked for.
@@ -38,7 +38,9 @@ export default function useProgressIndicator(initialValue, entityId) {
       setComplete(newState);
       setLoading(false);
     }
-  }, [list.list, entityId]);
+    // @FIXME Math.random() as a dependency here is a total hack,
+    // but it at least gets things working for now.
+  }, [list.list, entityId, Math.random()]);
 
   const markAsRead = () => {
     setComplete(true);


### PR DESCRIPTION
*THIS IS A TOTAL HACK*

After much investigation...

I can confirm that the main issue we're seeing with the tutorial progress code has to do with the `list.list` dependency in the `useProgressIndicator` hook. In this PR I've added `Math.random()` to the list of dependencies (so the component re-renders on every update). It's obviously not a good _solution_, but it at least gets things working for the end user. And at this point, I'm not entirely sure how to continue debugging the problem. My hunch is that there's an issue with the tutorialListProvider, or tutorialListReducer, but I haven't been able to find the source of the issue yet.

I'm not at all sure it's a good idea to merge this, but I wanted to at least have a place to track and communicate about the problem.