### PR TITLE
Allow use of cached response when retrieving a list of tutorials from Drupal.

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "gatsby-theme-osiolabs-drupal",
   "description": "Base theme for integrating with members.osiolabs.com.",
-  "version": "1.1.5",
+  "version": "1.2.0",
   "author": "Joe Shindelar <joe@osiolabs.com>",
   "main": "index.js",
   "dependencies": {

--- a/src/hooks/useProgressIndicator.js
+++ b/src/hooks/useProgressIndicator.js
@@ -32,7 +32,7 @@ export default function useProgressIndicator(initialValue, entityId, userId) {
   }
 
   function userReadState() {
-    if (list.list !== null && typeof list.list[entityId] !== 'undefined') {
+    if (list.list !== null && typeof list.list[entityId] !== 'undefined' && typeof list.list[entityId].tutorial_read_state !== 'undefined') {
       return list.list[entityId].tutorial_read_state;
     }
 
@@ -41,9 +41,13 @@ export default function useProgressIndicator(initialValue, entityId, userId) {
 
   // Then see if we can figure out what the value should be.
   useEffect(() => {
-    if (list.list !== null && typeof list.list[entityId] !== 'undefined') {
+    if (list.list !== null && typeof list.list[entityId] !== 'undefined' && typeof list.list[entityId].tutorial_read_state !== 'undefined') {
       const newState = list.list[entityId].tutorial_read_state === 'Read';
       setComplete(newState);
+      setLoading(false);
+    }
+    else {
+      setComplete(false);
       setLoading(false);
     }
   }, [userReadState()]);

--- a/src/hooks/useProgressIndicator.js
+++ b/src/hooks/useProgressIndicator.js
@@ -44,12 +44,8 @@ export default function useProgressIndicator(initialValue, entityId, userId) {
     if (list.list !== null && typeof list.list[entityId] !== 'undefined' && typeof list.list[entityId].tutorial_read_state !== 'undefined') {
       const newState = list.list[entityId].tutorial_read_state === 'Read';
       setComplete(newState);
-      setLoading(false);
     }
-    else {
-      setComplete(false);
-      setLoading(false);
-    }
+    setLoading(false);
   }, [userReadState()]);
 
   const markAsRead = () => {

--- a/src/hooks/useTutorialList/cacheFunctions.js
+++ b/src/hooks/useTutorialList/cacheFunctions.js
@@ -43,7 +43,16 @@ export async function getDataFromCache() {
     try {
       // The page[limit] is set to 30,000 which should be way more than the
       // most tutorials we'll ever have.
-      const url = `${process.env.GATSBY_DRUPAL_API_ROOT}/api/node/tutorial?filter[consumer.label][value]=heynode.com&fields[node--tutorial]=nid,title,tutorial_read_state&page[limit]=30000`;
+      let url;
+
+      // Use a different URL that doesn't include the tutorial_read_state field
+      // if the user is logged. This allows the anon user API request to be
+      //cached.
+      if (token) {
+        url = `${process.env.GATSBY_DRUPAL_API_ROOT}/api/node/tutorial?filter[consumer.label][value]=heynode.com&fields[node--tutorial]=nid,title,tutorial_read_state&page[limit]=30000`;
+      } else {
+        url = `${process.env.GATSBY_DRUPAL_API_ROOT}/api/node/tutorial?filter[consumer.label][value]=heynode.com&fields[node--tutorial]=nid,title&page[limit]=30000`;
+      }
 
       const headers = new Headers({
         Accept: 'application/vnd.api+json',


### PR DESCRIPTION
On the Drupal side the tutorial_read_state field is not cachable. So when it's included in the API request the returned response is not cacheable. However, anon users don't need the tutorial_read_state data because we don't track read state for anon users. So, by changing the API request for anon users to NOT include the field the resulting response can be cached by Drupal, CDNs and the user's browser. Yay!
