### PR TITLE
Run fixLinks() function on summary content

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "gatsby-theme-osiolabs-drupal",
   "description": "Base theme for integrating with members.osiolabs.com.",
-  "version": "1.2.0",
+  "version": "1.2.1",
   "author": "Joe Shindelar <joe@osiolabs.com>",
   "main": "index.js",
   "dependencies": {

--- a/src/components/drupal-components/DrupalTutorial.jsx
+++ b/src/components/drupal-components/DrupalTutorial.jsx
@@ -218,10 +218,18 @@ class AuthenticatedTutorial extends React.Component {
       bodyContent = fixLinks(propsToPassDown.body);
     }
 
+    let summaryContent;
+    if (data && data.attributes.summary.processed) {
+      summaryContent = data.attributes.summary.processed;
+    } else {
+      summaryContent = fixLinks(propsToPassDown.summary);
+    }
+
     // Display the coming soon version if it's flagged as such.
     if (tutorialAccess === 'coming_soon') {
       return React.createElement(comingSoonComponent, {
         ...propsToPassDown,
+        summary: fixLinks(propsToPassDown.summary),
         body: fixLinks(propsToPassDown.body),
       });
     }
@@ -231,6 +239,7 @@ class AuthenticatedTutorial extends React.Component {
     if (processing) {
       return React.createElement(loadingComponent, {
         ...propsToPassDown,
+        summary: fixLinks(propsToPassDown.summary),
         body: bodyContent,
         error,
       });
@@ -240,7 +249,7 @@ class AuthenticatedTutorial extends React.Component {
     const C = tutorialComponent;
     return (
       <>
-        <C {...propsToPassDown} body={bodyContent} error={error} />
+        <C {...propsToPassDown} body={bodyContent} summary={summaryContent} error={error} />
         <AutomaticProgressTracker
           currentReadState={currentReadState}
           entityId={propsToPassDown.id}

--- a/src/components/drupal-components/DrupalTutorial.test.jsx
+++ b/src/components/drupal-components/DrupalTutorial.test.jsx
@@ -67,6 +67,10 @@ describe('Component: <DrupalTutorial />', () => {
               processed:
                 'Processed body content + <p>Text with <a href="//example.com/tutorial/one">a link</a>',
             },
+            summary: {
+              processed:
+                'Processed summary content + <p>Text with <a href="//example.com/tutorial/one">a link</a>',
+            },
           },
         },
       })


### PR DESCRIPTION
Right now we display the summary content at the top of a tutorial for authenticated users without first running the `fixLinks()` function on that content. This can result in internal links to other tutorials not being properly re-written and ending up pointing to `members.osiolabs.com` instead of `heynode.com`.

Example, view this tutorial while signed in to the site and the link to the other tutorial just above the Goal heading points to the wrong domain.

https://heynode.com/tutorial/what-are-form-validation-and-sanitization/

This PR fixes that problem.

I've tested it locally, and it's working fine. And I also updated the tests. But it would be good to get a sanity check just to make sure I didn't do anything silly before merging this. Once that's done I can tag a new release and then also update heynode.com and get that deployed.