### PR TITLE
Do not ping API for personilization data for anon users.

### DIFF
--- a/src/hooks/useTutorialList/TutorialListProvider.jsx
+++ b/src/hooks/useTutorialList/TutorialListProvider.jsx
@@ -36,7 +36,11 @@ const TutorialListProvider = ({ children, currentUserId }) => {
         purgeDataFromCache();
       }
 
-      getDataFromCache().then(data => dispatch({ type: 'initialize', data }));
+      // If this is an anon user we don't need to bother pinging the API for
+      // personalization data.
+      if (currentUserId !== 'anon') {
+        getDataFromCache().then(data => dispatch({ type: 'initialize', data }));
+      }
     }
   }, [currentUserId]);
 

--- a/src/hooks/useTutorialList/TutorialListProvider.test.js
+++ b/src/hooks/useTutorialList/TutorialListProvider.test.js
@@ -29,7 +29,8 @@ describe('<TutorialListProvider />', () => {
     );
 
     await wait(() => getByText('Hello world'));
-    expect(getDataFromCache).toHaveBeenCalledTimes(1);
+    // We don't get data for anon users.
+    expect(getDataFromCache).toHaveBeenCalledTimes(0);
     expect(purgeDataFromCache).toHaveBeenCalledTimes(0);
 
     // Change the currentUserId, using rerender is the same as updating the
@@ -43,7 +44,7 @@ describe('<TutorialListProvider />', () => {
     );
 
     await wait(() => getByText('Hello world'));
-    expect(getDataFromCache).toHaveBeenCalledTimes(2);
+    expect(getDataFromCache).toHaveBeenCalledTimes(1);
     expect(purgeDataFromCache).toHaveBeenCalledTimes(1);
   });
 });


### PR DESCRIPTION
Right now we ping Drupal for a list of tutorial read state values even if the user is not signed in. But we don't need the data, and it's causing at least two requestions to Pantheon for every anon. page load. An OPTIONS request and a GET request. But the data it retrieves is never used for anon users. So we don't need to get it.

**Steps to test**

- Build heynode.com with this new code
- Verify that as an anon user can you still see the list of tutorials in the navigation sidebar and navigate the site

@blakehall it's probably pretty safe to do a code review and merge this. And then I can tag a release and build a new preview branch of heynode.com so we can verify things are working before deploying it to the live site.